### PR TITLE
New release of ocamlbuild (0.15.0) needs a new overlay release

### DIFF
--- a/packages/ocamlbuild/ocamlbuild.0.15.0+dune/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.15.0+dune/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
+authors: ["Nicolas Pouillard" "Berke Durak"]
+homepage: "https://github.com/ocaml/ocamlbuild/"
+bug-reports: "https://github.com/Leonidas-from-XIV/ocamlbuild/issues"
+license: "LGPL-2.0-or-later WITH OCaml-LGPL-linking-exception"
+doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
+dev-repo: "git+https://github.com/Leonidas-from-XIV/ocamlbuild.git"
+synopsis:
+  "OCamlbuild is a build system with builtin rules to easily build most OCaml projects"
+
+build: [
+  [
+    make
+    "-f"
+    "configure.make"
+    "all"
+    "OCAMLBUILD_PREFIX=%{prefix}%"
+    "OCAMLBUILD_BINDIR=%{bin}%"
+    "OCAMLBUILD_LIBDIR=%{lib}%"
+    "OCAMLBUILD_MANDIR=%{man}%"
+    "OCAML_NATIVE=%{ocaml:native}%"
+    "OCAML_NATIVE_TOOLS=%{ocaml:native}%"
+  ]
+  [make "check-if-preinstalled" "all" "opam-install"]
+]
+
+conflicts: [
+  "base-ocamlbuild"
+  "ocamlfind" {< "1.6.2"}
+]
+
+depends: [
+  "ocaml" {>= "4.08"}
+  "ocamlfind" {with-test}
+  "menhirLib" {with-test}
+]
+
+url {
+  src: "https://github.com/Leonidas-from-XIV/ocamlbuild/archive/refs/tags/0.15.0+dune.tar.gz"
+  checksum: [
+    "sha512=95f67e239798ecdd60685ae8f947c74f989d620cd4b214448c9c0813c90d6489c52662798384fbd9120cc974eef985de6af1169725e2d917eef0eafb127d81a4"
+  ]
+}


### PR DESCRIPTION
ocamlbuild 0.15.0 was released some time ago and it is not relocatable and triggers the symlink bug thus this PR adds an overlay for ocamlbuild 0.15.0 which replaces the symlink with a copy and incorporates @gridbugs relocation patch rebased on master.