### PR TITLE
fix(ocamlfind): handle +dune version suffix in configure script

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.9.8+dune/files/configure.patch
+++ b/packages/ocamlfind/ocamlfind.1.9.8+dune/files/configure.patch
@@ -1,0 +1,13 @@
+--- a/configure
++++ b/configure
+@@ -7,7 +7,9 @@
+ #   options, and for the "ocamlfind" frontend
+ # Adapted from the ocaml sources.
+
+-version="$(sed -ne 's/^version: *"\(.*\)\.git".*/\1/p' opam)"
++# Extract version from opam file, handling both .git and +dune suffixes
++# e.g., "1.9.8.git" -> "1.9.8", "1.9.8+dune" -> "1.9.8"
++version="$(sed -ne 's/^version: *"\([0-9][0-9.]*\)[.+].*/\1/p' opam)"
+
+ if test -z "$version"; then
+   echo "Internal error: failed to parse version number from opam file" 1>&2

--- a/packages/ocamlfind/ocamlfind.1.9.8+dune/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.8+dune/opam
@@ -38,6 +38,7 @@ install: [
   [make "install"]
   ["install" "-m" "0755" "ocaml-stub" "%{bin}%/ocaml"] {ocaml:preinstalled}
 ]
+patches: ["configure.patch"]
 dev-repo: "git+https://github.com/ocaml/ocamlfind.git"
 url {
   src:


### PR DESCRIPTION
## Summary

The ocamlfind configure script expects version format `X.Y.Z.git` in the opam file, but the overlay uses `X.Y.Z+dune`. When overwirting the opam file in the findlib source, this causes the build to fail with:

```
Internal error: failed to parse version number from opam file
```

The configure script has this sed command:
```bash
version="$(sed -ne 's/^version: *"\(.*\)\.git".*/\1/p' opam)"
```

Which only matches versions ending in `.git`, not `+dune`.